### PR TITLE
Update utils.format funcion based on config object. Now returns a func

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -165,6 +165,37 @@ export default function Chart(config) {
      * Keep default configuration in other case.
      */
     vm._config = config ? _.cloneDeep(config) : defaultConfig;
+
+    if (vm._config.xAxis) {
+      vm._config.xAxis.axis = 'xAxis';
+      /**
+       * @deprecated Allow to use general config if axis-based is not especified
+       */
+      if (vm._config.xAxis.decimals === undefined && vm._config.decimals !== undefined) {
+        vm._config.xAxis.decimals = vm._config.decimals;
+      }
+      if (vm._config.xAxis.formatPreffix === undefined && vm._config.formatPreffix !== undefined) {
+        vm._config.xAxis.formatPreffix = vm._config.formatPreffix;
+      }
+      if (vm._config.xAxis.formatSuffix === undefined && vm._config.formatSuffix !== undefined) {
+        vm._config.xAxis.formatSuffix = vm._config.formatSuffix;
+      }
+    }
+    if (vm._config.yAxis) {
+      vm._config.yAxis.axis = 'yAxis';
+      /**
+       * @deprecated Allow to use general config if axis-based is not especified
+       */
+      if (vm._config.yAxis.decimals === undefined && vm._config.decimals !== undefined) {
+        vm._config.yAxis.decimals = vm._config.decimals;
+      }
+      if (vm._config.yAxis.formatPreffix === undefined && vm._config.formatPreffix !== undefined) {
+        vm._config.yAxis.formatPreffix = vm._config.formatPreffix;
+      }
+      if (vm._config.yAxis.formatSuffix === undefined && vm._config.formatSuffix !== undefined) {
+        vm._config.yAxis.formatSuffix = vm._config.formatSuffix;
+      }
+    }
     // Initialize data array
     vm._data = [];
 
@@ -523,7 +554,7 @@ export default function Chart(config) {
 
     if (vm._config.xAxis && vm._config.xAxis.ticks && vm._config.xAxis.scale === 'linear') {
       vm._scales.x.domain()[1];
-      axes.x.tickFormat(vm.helper.utils.format);
+      axes.x.tickFormat(vm.helper.utils.format(vm._config.xAxis, true));
     }
     if (vm._config.xAxis && vm._config.xAxis.ticks && vm._config.xAxis.ticks.format) {
       axes.x.tickFormat(vm._config.xAxis.ticks.format);
@@ -558,13 +589,11 @@ export default function Chart(config) {
       }
     }
     if (vm._config.yAxis && vm._config.yAxis.ticks && vm._config.yAxis.scale === 'linear') {
-
-      axes.y.tickFormat(vm.helper.utils.format);
+      axes.y.tickFormat(vm.helper.utils.format(vm._config.yAxis, true));
     }
     if (vm._config.yAxis && vm._config.yAxis.ticks && vm._config.yAxis.ticks.format) {
       axes.y.tickFormat(vm._config.yAxis.ticks.format);
     }
-
     if (vm._config.yAxis && vm._config.yAxis.ticks && vm._config.yAxis.ticks.ticks) {
       axes.y.ticks(vm._config.yAxis.ticks.ticks);
     }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -148,85 +148,105 @@ export default function () {
     return scale;
   };
 
-  Helper.utils.format = function (d, smallVersion, decimals) {
-    if (Number.isNaN(Number(d))) { // d is not a number, return original value
-      return d;
+  /**
+   * Format numbers
+   * @param {Object} config - configurate current formatter
+   * @param {number} config.decimals - Quantity of decimals to use
+   * @param {string} config.axis - Current scale selected from axis ['xAxis', 'yAxis']
+   * @param {string} config.formatPreffix - Preffix to use in formatting. Eg. '$'
+   * @param {string} config.formatSuffix - Suffix to use in formatting. Eg. '%'
+   * @param {boolean} [smallNumber] - Display number in small format
+   * @returns Function configured to parse a number [d]
+   */
+  Helper.utils.format = function (config, smallNumber) {
+    if (!config) {
+      // Default config
+      var linearAxis = vm._config.yAxis && vm._config.yAxis.scale === 'linear' ?
+        'yAxis' : vm._config.xAxis && vm._config.xAxis.scale === 'linear' ?
+        'xAxis' : '';
+      config = {
+        decimals: vm._config.decimals,
+        axis: linearAxis,
+        formatPreffix: vm._config.formatPreffix,
+        formatSuffix: vm._config.formatSuffix
+      };
     }
-    var fullNumber = smallVersion ? false : true;
-    var floatingPoints = 1;
-    if (vm._config.decimals) {
-      floatingPoints = Number(vm._config.decimals);
-    }
-    if (decimals && Number.isInteger(decimals)) {
-      floatingPoints = decimals;
-    }
-    var value = '';
-    if (vm._config.formatPreffix) {
-      value += vm._config.formatPreffix;
-    }
-    var suffix = '';
-    
-    if (!fullNumber) {
-      
-      var linearAxis = vm._config.yAxis && vm._config.yAxis.scale === 'linear' && (_.inRange(d, vm._scales.y.domain()[0], vm._scales.y.domain()[1]) || d === vm._scales.y.domain()[1]) ? 'yAxis' : vm._config.xAxis && vm._config.xAxis.scale === 'linear' && (_.inRange(d, vm._scales.x.domain()[0], vm._scales.x.domain()[1]) || d === vm._scales.x.domain()[1]) ? 'xAxis' : '';
-      var mean = d3.mean(vm._scales[linearAxis.replace('Axis','')].ticks());
-      
-      if (mean >= 1000000000000) {
-        if (linearAxis) {
-          vm._config[linearAxis].text = 'Billones';
-        } else {
-          suffix = ' billones';
-        }
-        d = d / 1000000000000;
-      } else if (mean >= 1000000000) { // Thousands of millions
-        if (linearAxis) {
-          vm._config[linearAxis].text = 'Miles de millones';
-        } else {
-          suffix = ' mil millones';
-        }
-        d = d / 1000000000;
-      } else if (mean >= 1000000) { // Millions
-        if (linearAxis) {
-          vm._config[linearAxis].text = 'Millones';
-        } else {
-          suffix = ' millones';
-        }
-        d = d / 1000000;
-      } else if (mean >= 10000) { // Thousands
-        if (linearAxis) {
-          vm._config[linearAxis].text = 'Miles';
-        } else {
-          suffix = ' mil';
-        }
-        d = d / 1000;
+    return function (d) {
+      if (Number.isNaN(Number(d))) { // d is not a number, return original value
+        return d;
       }
-    }
-    
-    if (Number.isInteger(d)) {
-      value += d3.format(',.0f')(d);
-    } else if (d > 1) {
-      value += d3.format(',.' + floatingPoints + 'f')(d);
-    } else {
-      var floats = d.toString().split('.')[1];
-      var points = 1;
-      if (floats) {
-        for (let index = 0; index < floats.length; index++) {
-          const number = Number(floats[index]);
-          if (number === 0) {
-            points += 1;
+      var fullNumber = smallNumber ? false : true;
+      var floatingPoints = 1; // Default
+      if (config.decimals !== undefined && Number.isInteger(config.decimals)) {
+        floatingPoints = Number(config.decimals);
+      }
+      var value = '';
+      if (config.formatPreffix) {
+        value += config.formatPreffix;
+      }
+      var suffix = '';
+
+      if (!fullNumber) {
+        var currentAxis = config.axis;
+        var mean = d3.mean(vm._scales[currentAxis.replace('Axis', '')].ticks());
+
+        if (mean >= 1000000000000) {
+          if (currentAxis) {
+            vm._config[currentAxis].text = 'Billones';
           } else {
-            break;
+            suffix = ' billones';
           }
+          d = d / 1000000000000;
+        } else if (mean >= 1000000000) { // Thousands of millions
+          if (currentAxis) {
+            vm._config[currentAxis].text = 'Miles de millones';
+          } else {
+            suffix = ' mil millones';
+          }
+          d = d / 1000000000;
+        } else if (mean >= 1000000) { // Millions
+          if (currentAxis) {
+            vm._config[currentAxis].text = 'Millones';
+          } else {
+            suffix = ' millones';
+          }
+          d = d / 1000000;
+        } else if (mean >= 10000) { // Thousands
+          if (currentAxis) {
+            vm._config[currentAxis].text = 'Miles';
+          } else {
+            suffix = ' mil';
+          }
+          d = d / 1000;
         }
-        value += d3.format(',.' + points + 'f')(d);
       }
+
+      if (Number.isInteger(d)) {
+        value += d3.format(',.0f')(d);
+      } else if (d > 1) {
+        value += d3.format(',.' + floatingPoints + 'f')(d);
+      } else {
+        var floats = d.toString().split('.')[1];
+        var points = 1;
+        if (floats) {
+          for (let index = 0; index < floats.length; index++) {
+            const number = Number(floats[index]);
+            if (number === 0) {
+              points += 1;
+            } else {
+              break;
+            }
+          }
+          value += d3.format(',.' + points + 'f')(d);
+        }
+      }
+      value += suffix;
+
+      if (config.formatSuffix && value.indexOf(config.formatSuffix) < 0) {
+        value += config.formatSuffix;
+      }
+      return value;
     }
-    value += suffix;
-    
-    if (vm._config.formatSuffix && value.indexOf(vm._config.formatSuffix) < 0) {
-      value += vm._config.formatSuffix;
-    }
-    return value;
   };
 
   // wrap function used in x axis labels
@@ -329,24 +349,24 @@ export default function () {
       lineNumber = 0,
       lineHeight = 0.7, //ems
       scrollTop = 0;
-      //egendBoxBackgroundHeight = d3.select('.legendBoxBackground').attr('height');
+    //egendBoxBackgroundHeight = d3.select('.legendBoxBackground').attr('height');
 
-    
+
     function virtualscroller(container) {
       function render(resize) {
         if (resize) {
           /*
-            * Tested values:
-            * 240 -> 9 rows
-            * 170 ->13 rows 
+           * Tested values:
+           * 240 -> 9 rows
+           * 170 ->13 rows 
            */
           viewportHeight = parseInt(viewport.style('height')) - 170;
           visibleRows = Math.ceil(viewportHeight / rowHeight);
         }
         var lastPosition = position;
-        if(position < data.length && position >= 0 && scrollTop < 0) {
+        if (position < data.length && position >= 0 && scrollTop < 0) {
           position += 1;
-        } else if(position <= data.length && position > 0 && scrollTop > 0) {
+        } else if (position <= data.length && position > 0 && scrollTop > 0) {
           position -= 1;
         }
         delta = position - lastPosition;
@@ -362,7 +382,7 @@ export default function () {
           rowSelection.exit().call(exit).remove();
           rowSelection.enter().append('g')
             .attr('class', 'legend-checkbox legend')
-            .attr('random', function(d) {
+            .attr('random', function (d) {
               return d;
             })
             .call(enter)
@@ -377,12 +397,12 @@ export default function () {
               }
               d3.event.stopPropagation();
             });
-            
+
           rowSelection.order();
           var rowUpdateSelection = container.selectAll('.legend-checkbox');
-          
+
           rowUpdateSelection.call(update);
-          
+
           rowUpdateSelection.each(function (d, i) {
             d3.select(this)
               .attr('font-weight', 'bold')
@@ -399,14 +419,14 @@ export default function () {
             .style('fill', 'white'); */
         });
       }
-        
+
       virtualscroller.render = render;
       let isFirefox = typeof InstallTrigger !== 'undefined';
       let support = "onwheel" in d3.select('.legendBox') ? "wheel" : // Modern browsers support "wheel"
-                  document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
-                  "wheel"; // let's assume that remaining browsers are older Firefox
+        document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
+        "wheel"; // let's assume that remaining browsers are older Firefox
       d3.select('.legendBox').on(support, function () { // isFirefox ? 'wheel' : 'mousewheel.zoom'
-                                                        //Chrome & IE: mousewheel.zoom | Firefox: DOMMouseScroll (not supported yet). 
+        //Chrome & IE: mousewheel.zoom | Firefox: DOMMouseScroll (not supported yet). 
         var evt = d3.event;
         evt.preventDefault();
         scrollTop = isFirefox ? evt.deltaY : evt.wheelDelta;
@@ -422,22 +442,22 @@ export default function () {
         .attr('class', 'scroll-legend')
         .append('text')
         .attr('transform', `translate(0,${visibleRows * 25})`);
-      
+
       scrollLegend.append('tspan')
         .attr('class', 'material-icons expand-more')
         .text('mouse');
-      
+
       scrollLegend.append('tspan')
         .attr('x', 30)
         .attr('y', -12)
         .text('Desplázate con el');
-      
+
       scrollLegend.append('tspan')
         .attr('x', 60)
         .attr('y', -1)
         .text('cursor');
 
-      if(totalRows < visibleRows) {
+      if (totalRows < visibleRows) {
         d3.selectAll('.scroll-legend').style('display', 'none');
       } else {
         d3.selectAll('.scroll-legend').style('display', 'flex');
@@ -499,7 +519,7 @@ export default function () {
       if (!arguments.length) return position;
       position = +_;
       if (viewport) {
-        
+
         viewport.node().scrollTop = position;
       }
       return virtualscroller;
@@ -531,17 +551,19 @@ export default function () {
       return virtualscroller;
     };
 
-    const rebind = function(target, source) {
-      var i = 1, n = arguments.length, method;
+    const rebind = function (target, source) {
+      var i = 1,
+        n = arguments.length,
+        method;
       while (++i < n) target[method = arguments[i]] = d3_rebind(target, source, source[method]);
       return target;
     };
-    
+
     // Method is assumed to be a standard D3 getter-setter:
     // If passed with no arguments, gets the value.
     // If passed with arguments, sets the value and returns the target.
     function d3_rebind(target, source, method) {
-      return function() {
+      return function () {
         var value = method.apply(source, arguments);
         return value === source ? target : value;
       };

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -5,47 +5,47 @@ describe('Helper.utils', function() {
   describe('format()', function() {
     it('Should format 5450000 to 5.5 millones', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(5450000, true);
+      var result = chart.helper.utils.format(null, true)(5450000);
       assert.equal(result, '5.5 millones');
     });
     it('Should format 430958 to 431.0 mil', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(430958, true);
+      var result = chart.helper.utils.format(null, true)(430958);
       assert.equal(result, '431.0 mil');
     });
     it('Should format 6234 to 6.2 mil', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(6234, true);
+      var result = chart.helper.utils.format(null, true)(6234);
       assert.equal(result, '6.2 mil');
     });
     it('Should format 345.23 to 345.2', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(345.23, true);
+      var result = chart.helper.utils.format(null, true)(345.23);
       assert.equal(result, '345.2');
     });
     it('Should format 5.2093 to 5.2', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(5.2093, true);
+      var result = chart.helper.utils.format(null, true)(5.2093);
       assert.equal(result, '5.2');
     });
     it('Should format 12.0 to 12', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(12.0, true);
+      var result = chart.helper.utils.format(null, true)(12.0);
       assert.equal(result, '12');
     });
     it('Should format 1.4904 to 1.5', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(1.4904, true);
+      var result = chart.helper.utils.format(null, true)(1.4904);
       assert.equal(result, '1.5');
     });
     it('Should format 0.4935 to 0.5 ', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(0.4935, true);
+      var result = chart.helper.utils.format(null, true)(0.4935);
       assert.equal(result, '0.5');
     });
     it('Should format 0.00435 to 0.004 ', function() {
       var chart = dbox.chart();
-      var result = chart.helper.utils.format(0.00435, true);
+      var result = chart.helper.utils.format(null, true)(0.00435);
       assert.equal(result, '0.004');
     });
   });


### PR DESCRIPTION
Se agregó funcionalidad para manejar el formato de los números dependiendo del eje, esto sobretodo para evitar que en el scatter que se comparan dos indicadores INDEPENDIENTES, salgan los dos con símbolos de porcentajes o de pesos, siendo que solo uno debería tenerlo.

Ahora utils.format recibe un objeto de configuración y devuelve una función para formatear los números. 

![image](https://user-images.githubusercontent.com/6007352/62396734-8de6fe80-b539-11e9-84c7-1c6c23c719dd.png)
